### PR TITLE
Add merge-pr.whitespace config, defaults to nowarn

### DIFF
--- a/git-merge-pr
+++ b/git-merge-pr
@@ -30,7 +30,8 @@ fi
 PATCH="$(mktemp)"
 trap "rm -f $PATCH" INT TERM EXIT
 wget -nv -O "$PATCH" https://github.com/$PROJECT/pull/"$PR".patch
-git am "$@" "$PATCH"
+WHITESPACE="$(git config --get merge-pr.whitespace)"
+git am "--whitespace=${WHITESPACE:-nowarn}" "$@" "$PATCH"
 
 if [ "$(git config --bool --get merge-pr.autoclose)" = false ]; then
 	exit 0


### PR DESCRIPTION
This adds a new `merge-pr.whitespace` option and passes it to `git-am` as the first argument. The default is `nowarn`, so PR series are applied verbatim and without whitespace warnings, just like with `git merge`. Users can still pass a temporary whitespace policy on the command line.

I noticed this because in one of my PRs applied with `git-merge-pr`, a newly added patch file against tab-indented C had its initial spaces stripped, presumably because the committer's Git config was set to `apply.whitespace fix`.